### PR TITLE
Fixed memory leak in dfuProbeDevices

### DIFF
--- a/main.c
+++ b/main.c
@@ -41,7 +41,22 @@ void libusbClose() {
   //ctx = NULL;
 }
 
+void freeDfuIf(struct dfu_if *pdfu) {
+    libusb_unref_device(pdfu->dev);
+    free(pdfu->alt_name);
+    free(pdfu->serial_name);
+    free(pdfu);
+}
+
+void clearDfuRoot() {
+  while (dfu_root) {
+    struct dfu_if *pdfu = dfu_root;
+    dfu_root = dfu_root->next;
+    freeDfuIf(pdfu);
+  }
+}
+
 void dfuProbeDevices() {
-  dfu_root = NULL;
+  clearDfuRoot();
   probe_devices(ctx);
 }


### PR DESCRIPTION
Before the patch, after leaving `dfu-discovery` running in `START_SYNC` for a while, `valgrind` reported the following:

```
==158475== LEAK SUMMARY:
==158475==    definitely lost: 159,920 bytes in 1,999 blocks
==158475==    indirectly lost: 629,393 bytes in 15,986 blocks
==158475==      possibly lost: 4,910 bytes in 40 blocks
==158475==    still reachable: 4,649 bytes in 39 blocks
==158475==         suppressed: 0 bytes in 0 blocks
```

after the patch:

```
==158014== LEAK SUMMARY:
==158014==    definitely lost: 0 bytes in 0 blocks
==158014==    indirectly lost: 0 bytes in 0 blocks
==158014==      possibly lost: 2,215 bytes in 11 blocks
==158014==    still reachable: 7,695 bytes in 65 blocks
==158014==         suppressed: 0 bytes in 0 blocks
```

Fix #16