### PR TITLE
Add CI workflow to publish tester builds

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -1,0 +1,164 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/publish-go-tester-task.md
+name: Publish Tester Build
+
+# See: https://docs.github.com/actions/using-workflows/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/publish-go-tester-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
+      - "**.go"
+  pull_request:
+    paths:
+      - ".github/workflows/publish-go-tester-task.ya?ml"
+      - "go.mod"
+      - "go.sum"
+      - "Taskfile.ya?ml"
+      - "DistTasks.ya?ml"
+      - "**.go"
+  workflow_dispatch:
+  repository_dispatch:
+
+env:
+  # As defined by the Taskfile's PROJECT_NAME variable
+  PROJECT_NAME: dfu-discovery
+  # As defined by the Taskfile's DIST_DIR variable
+  DIST_DIR: dist
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          TAG_REGEX="refs/tags/.*"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            ("${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) &&
+            ! "${{ github.ref }}" =~ $TAG_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  package-name-prefix:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      prefix: ${{ steps.calculation.outputs.prefix }}
+    steps:
+      - name: package name prefix calculation
+        id: calculation
+        run: |
+          PACKAGE_NAME_PREFIX="test"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.event.number }}"
+          fi
+          PACKAGE_NAME_PREFIX="$PACKAGE_NAME_PREFIX-${{ github.sha }}-"
+
+          echo "prefix=$PACKAGE_NAME_PREFIX" >> $GITHUB_OUTPUT
+
+  build:
+    needs: package-name-prefix
+    name: Build ${{ matrix.os.name }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os:
+          - task: Windows_32bit
+            path: "*Windows_32bit.zip"
+            name: Windows_X86-32
+          - task: Windows_64bit
+            path: "*Windows_64bit.zip"
+            name: Windows_X86-64
+          - task: Linux_32bit
+            path: "*Linux_32bit.tar.gz"
+            name: Linux_X86-32
+          - task: Linux_64bit
+            path: "*Linux_64bit.tar.gz"
+            name: Linux_X86-64
+          - task: Linux_ARMv6
+            path: "*Linux_ARMv6.tar.gz"
+            name: Linux_ARMv6
+          - task: Linux_ARMv7
+            path: "*Linux_ARMv7.tar.gz"
+            name: Linux_ARMv7
+          - task: Linux_ARM64
+            path: "*Linux_ARM64.tar.gz"
+            name: Linux_ARM64
+          - task: macOS_64bit
+            path: "*macOS_64bit.tar.gz"
+            name: macOS_64
+          - task: macOS_ARM64
+            path: "*macOS_ARM64.tar.gz"
+            name: macOS_ARM64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Download dfu-util
+        run: task download-dfu-util
+
+      - name: Build
+        run: |
+          PACKAGE_NAME_PREFIX=${{ needs.package-name-prefix.outputs.prefix }}
+          export PACKAGE_NAME_PREFIX
+          task dist:${{ matrix.os.task }}
+
+      # Transfer builds to artifacts job
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
+          name: ${{ matrix.os.name }}
+
+  checksums:
+    needs:
+      - build
+      - package-name-prefix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Create checksum file
+        run: |
+          TAG="${{ needs.package-name-prefix.outputs.prefix }}git-snapshot"
+          declare -a artifacts=($(ls -d */))
+          for artifact in ${artifacts[@]}
+          do
+            cd $artifact
+            checksum=$(sha256sum ${{ env.PROJECT_NAME }}_${TAG}*)
+            cd ..
+            echo $checksum >> ${TAG}-checksums.txt
+          done
+
+      - name: Upload checksum artifact
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./*checksums.txt
+          name: checksums

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Check Go Dependencies status](https://github.com/arduino/dfu-discovery/actions/workflows/check-go-dependencies-task.yml/badge.svg)](https://github.com/arduino/dfu-discovery/actions/workflows/check-go-dependencies-task.yml)
 [![Check License status](https://github.com/arduino/dfu-discovery/actions/workflows/check-license.yml/badge.svg)](https://github.com/arduino/dfu-discovery/actions/workflows/check-license.yml)
 [![Check Go status](https://github.com/arduino/dfu-discovery/actions/workflows/check-go-task.yml/badge.svg)](https://github.com/arduino/dfu-discovery/actions/workflows/check-go-task.yml)
+[![Publish Tester Build status](https://github.com/arduino/dfu-discover/actions/workflows/publish-go-tester-task.yml/badge.svg)](https://github.com/arduino/dfu-discovery/actions/workflows/publish-go-tester-task.yml)
 
 The `dfu-discovery` tool is a command line program that interacts via stdio. It accepts commands as plain ASCII strings terminated with LF `\n` and sends response as JSON.
 


### PR DESCRIPTION
On every commit to a pull request or the repository:

- Build the project for all supported platforms.
- Upload the builds as [workflow artifacts](https://docs.github.com/actions/using-workflows/storing-workflow-data-as-artifacts).

This makes it possible for any interested party to participate in beta testing without setting up a build system locally.